### PR TITLE
New VEP_plugins and a plugin fix

### DIFF
--- a/Downstream.pm
+++ b/Downstream.pm
@@ -111,7 +111,7 @@ sub run {
         my $new_length = ($tv->translation_start < $tv->translation_end ? $tv->translation_start : $tv->translation_end) + length($new_pep);
         
         return {
-            Downstream          => $new_pep,
+            DownstreamProtein   => $new_pep,
             ProteinLengthChange => $new_length - length($translation),
         };
     }

--- a/Wildtype.pm
+++ b/Wildtype.pm
@@ -1,0 +1,72 @@
+=head1 NAME
+
+ Wildtype
+
+=head1 SYNOPSIS
+
+ mv Wildtype.pm ~/.vep/Plugins
+ perl variant_effect_predictor.pl -i variations.vcf --plugin Wildtype
+
+=head1 DESCRIPTION
+
+ This is a plugin for the Ensembl Variant Effect Predictor (VEP) that
+ provides the wildtype protein sequence of a transcript.
+
+=cut
+
+package Wildtype;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
+
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
+
+sub version {
+    return '1.0';
+}
+
+sub feature_types {
+    return ['Transcript'];
+}
+
+sub get_header_info {
+    return {
+        WildtypeProtein     => "The normal, non-mutated protein sequence",
+    };
+}
+
+sub run {
+    my ($self, $tva) = @_;
+
+    my $tv = $tva->transcript_variation;
+    my $tr = $tv->transcript;
+    my $cds_seq = defined($tr->{_variation_effect_feature_cache}) ? $tr->{_variation_effect_feature_cache}->{translateable_seq} : $tr->translateable_seq;
+    my $codon_seq = Bio::Seq->new(
+        -seq      => $cds_seq,
+        -moltype  => 'dna',
+        -alphabet => 'dna'
+    );
+
+    #get codon table
+    my $codon_table;
+    if(defined($tr->{_variation_effect_feature_cache})) {
+        $codon_table = $tr->{_variation_effect_feature_cache}->{codon_table} || 1;
+    }
+    else {
+        my ($attrib) = @{$tr->slice->get_all_Attributes('codon_table')};
+        $codon_table = $attrib ? $attrib->value || 1 : 1;
+    }
+
+    # translate
+    my $new_pep = $codon_seq->translate(undef, undef, undef, $codon_table)->seq();
+    $new_pep =~ s/\*.*//;
+
+    return {
+        WildtypeProtein => $new_pep,
+    };
+}
+
+1;
+


### PR DESCRIPTION
This PR introduces a new plugin "Wildtype" which returns the wildtype protein sequence for a transcript. It also fixes the return hash for the Downstream plugin to match its keys to the keys in the get_header_info hash.
